### PR TITLE
fix: Mysql2::Error: Specified key was too long; max key length is 767…

### DIFF
--- a/config/initializers/mysql.rb
+++ b/config/initializers/mysql.rb
@@ -1,0 +1,9 @@
+require 'active_record/connection_adapters/abstract_mysql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter
+      NATIVE_DATABASE_TYPES[:string] = { :name => "varchar", :limit => 191 }
+    end
+  end
+end


### PR DESCRIPTION
… bytes対応